### PR TITLE
Add BreadBuddy to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -326,7 +326,7 @@
     "actions": [
       {
         "action": "BuildXcodeProjectTarget",
-        "project": "BreadBuddy/BreadBuddy.xcodeproj",
+        "project": "BreadBuddy.xcodeproj",
         "target": "BreadBuddy",
         "destination": "generic/platform=iOS",
         "configuration": "Release"

--- a/projects.json
+++ b/projects.json
@@ -314,11 +314,12 @@
     "path": "BreadBuddy",
     "branch": "master",
     "maintainer": "max@bracket.ltd",
-    "compatibility": {
-      "5.6.1": {
+    "compatibility": [
+      {
+        "version": "5.0",
         "commit": "28558470aa2ef75a96156ab00aa6d42d05eac884"
       }
-    },
+    ],
     "platforms": [
       "Darwin"
     ],

--- a/projects.json
+++ b/projects.json
@@ -310,6 +310,30 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/maxhumber/BreadBuddy",
+    "path": "BreadBuddy",
+    "branch": "master",
+    "maintainer": "max@bracket.ltd",
+    "compatibility": {
+      "5.6.1": {
+        "commit": "28558470aa2ef75a96156ab00aa6d42d05eac884"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "BreadBuddy/BreadBuddy.xcodeproj",
+        "target": "BreadBuddy",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/carekit-apple/CareKit.git",
     "path": "CareKit",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

[BreadBuddy](https://github.com/maxhumber/BreadBuddy) is an open-source reference app for using MVVM with SwiftUI.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an **Xcode** or *swift package manager* project
- [x] support building on either Linux or **macOS**
- [x] target Linux, macOS, or **iOS**/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* **BSD**
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
