### PR TITLE
GRDB compatiblity with Swift 6.0

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1003,7 +1003,7 @@
       },
       {
         "version": "6.0",
-        "commit": "3ecb5c54553559217592d21a6d9841becb891b38"
+        "commit": "6eba24d16952452a8a54f6a639491f3c8215527f"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -1000,6 +1000,10 @@
       {
         "version": "5.7",
         "commit": "2d19cab2b525f885ee8d7efec96093431f6b5f20"
+      },
+      {
+        "version": "6.0",
+        "commit": "3ecb5c54553559217592d21a6d9841becb891b38"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

Hello, this pull request adds compatibility check for GRDB with Swift 6.0.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [X] be an *Xcode* or *swift package manager* project
- [X] support building on either Linux or macOS
- [X] target Linux, macOS, or iOS/tvOS/watchOS device
- [X] be contained in a publicly accessible git repository
- [X] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [X] have maintainers who will commit to resolve issues in a timely manner
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [X] add value not already included in the suite
- [X] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [ ] pass `./project_precommit_check` script run

The last check does not pass, due to the lack of support for Swift 6.0 in `project_precommit_check` (see #963).