### PR TITLE
fix: Use --package-path for test actions

### DIFF
--- a/project.py
+++ b/project.py
@@ -364,7 +364,8 @@ def test_swift_package(path, swiftc, sandbox_profile,
     """Test a Swift package manager project."""
     swift = os.path.join(os.path.dirname(swiftc), 'swift')
     if not incremental:
-        clean_swift_package(path, swiftc, sandbox_profile)
+        clean_swift_package(path, swiftc, sandbox_profile,
+                            stdout=stdout, stderr=stderr)
     env = os.environ
     env['SWIFT_EXEC'] = override_swift_exec or swiftc
     command = [swift, 'test', '--package-path', path, '--verbose']

--- a/project.py
+++ b/project.py
@@ -367,7 +367,7 @@ def test_swift_package(path, swiftc, sandbox_profile,
         clean_swift_package(path, swiftc, sandbox_profile)
     env = os.environ
     env['SWIFT_EXEC'] = override_swift_exec or swiftc
-    command = [swift, 'test', '-C', path, '--verbose']
+    command = [swift, 'test', '--package-path', path, '--verbose']
     if added_swift_flags is not None:
         for flag in added_swift_flags.split():
             command += ["-Xswiftc", flag]


### PR DESCRIPTION
### Pull Request Description
Updates the usage of `swift test` to use `--package-path` instead of the deprecated `-C`.

Resolves `Unknown option '-C'` errors when attempting to run TestSwiftPackage actions.

Also includes a minor refactor to prevent extraneous `swift package clean` debug output from printing. This was due to a difference in `clean_swift_package` arguments.

### Acceptance Criteria
N/A -- no new project is being submitted for review