### PR TITLE
XFAIL Doggie in Debug configuration on main branch

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -786,7 +786,7 @@
             {
                 "issue": "https://github.com/apple/swift/issues/70764",
                 "compatibility": "5.0",
-                "branch": ["release/5.9", "release/5.10", "release/6.0", "release/6.1"],
+                "branch": ["main", "release/5.9", "release/5.10", "release/6.0", "release/6.1"],
                 "configuration": "debug",
                 "platform": "Darwin",
                 "job": ["source-compat"]


### PR DESCRIPTION
The constraint solver performance changes are reverted via https://github.com/swiftlang/swift/pull/79128 which means that Doggie tests are going to fail again.