### PR TITLE
[Violet] Fix for Swift 6.1 compatibility with `Foundation.Expression`.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -5140,7 +5140,7 @@
      "compatibility": [
        {
          "version": "5.3",
-         "commit": "8217bfb0761c1630c94b88cc1fbe842bba40eb3d"
+         "commit": "01693c2e4010a788dfd96e9b494b6c4b926262ca"
        }
      ],
      "platforms": [


### PR DESCRIPTION
Fix for #955 with Swift 6.1. Tested against `swift-6.1-DEVELOPMENT-SNAPSHOT-2025-02-10-a-ubuntu24.04`.

# Failure

```swift
/build/swift-source-compat-suite/project_cache/violet/Sources/Compiler/Implementation/CompilerImpl+Expr.swift:14:31: error: 'Expression' is ambiguous for type lookup in this context
 12 | extension CompilerImpl {
 13 | 
 14 |   internal func visit(_ node: Expression) throws {
    |                               `- error: 'Expression' is ambiguous for type lookup in this context
 15 |     self.setAppendLocation(node)
 16 |     try node.accept(self)
```

# Local run

```
➜  swift-source-compat-suite git:(main) ✗ ./runner.py \
  --swift-branch main \
  --projects projects.json \
  --include-actions 'action.startswith("Build")' \
  --include-repos 'path == "violet"' \
  --swiftc /home/michal/Downloads/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-02-10-a-ubuntu24.04/usr/bin/swiftc


Building 1 projects across 4 parallel processes

UPASS: https://github.com/swiftlang/swift/issues/75499, violet, 5.3, 01693c, Swift Package
========================================
UPasses:
  UPASS: https://github.com/swiftlang/swift/issues/75499, violet, 5.3, 01693c, Swift Package
========================================
Action Summary:
     Passed: 0
     Failed: 0
    XFailed: 0
    UPassed: 1
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: UPASS
========================================
```