### PR TITLE
Do not use stat cache in compatibility suite

### DIFF
--- a/project.py
+++ b/project.py
@@ -160,6 +160,7 @@ class XcodeTarget(ProjectTarget):
                       "MACOSX_DEPLOYMENT_TARGET=10.13",
                       "WATCHOS_DEPLOYMENT_TARGET=4.0",
                       "TVOS_DEPLOYMENT_TARGET=16.0",
+                      "SDK_STAT_CACHE_ENABLE=NO",
                       ])
         command += self._added_xcodebuild_flags
 
@@ -222,6 +223,7 @@ class XcodeTarget(ProjectTarget):
                       "MACOSX_DEPLOYMENT_TARGET=10.13",
                       "WATCHOS_DEPLOYMENT_TARGET=4.0",
                       "TVOS_DEPLOYMENT_TARGET=16.0",
+                      "SDK_STAT_CACHE_ENABLE=NO",
                       ])
         command += self._added_xcodebuild_flags
 


### PR DESCRIPTION
This will prevent build issues like

```
error: missing required module 'SwiftShims
```

when the `clang-stat-cache` present in the
Xcode installed in CI comes from an LLVM older than the one used
 to build Swift (and in turn used by the ClangImporter).

Addresses rdar://144053750