### PR TITLE
Set locale for perl binary after OS update

### DIFF
--- a/project.py
+++ b/project.py
@@ -397,12 +397,14 @@ def strip_resource_phases(repo_path, stdout=sys.stdout, stderr=sys.stderr):
     """Strip resource build phases from a given project."""
     command = ['perl', '-i', '-00ne',
                'print unless /Begin PBXResourcesBuildPhase/']
+    env = os.environ.copy()
+    env['LANG'] ='en_US.UTF-8'
     for root, dirs, files in os.walk(repo_path):
         for filename in files:
             if filename == 'project.pbxproj':
                 pbxfile = os.path.join(root, filename)
                 common.check_execute(command + [pbxfile],
-                                     stdout=stdout, stderr=stderr)
+                                     stdout=stdout, stderr=stderr, env=env)
 
 
 def dispatch(root_path, repo, action, swiftc, swift_version,


### PR DESCRIPTION
After the OS update we see certain projects fail with
```
panic: locale.c: 4486: Could not change LC_CTYPE locale to C.UTF-8, errno=9
```

This is because the perl binary seems to be not able to find the correct locale after the OS update. This PR rectifies that by setting the value accordingly when making a subprocess call to perl
