### PR TITLE
Update stress tester XFAILs

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -6012,7 +6012,7 @@
     "path": "*\/ACHNBrowserUI\/ACHNBrowserUI\/views\/turnips\/charts\/TurnipsChartVerticalLegend.swift"
   },
   {
-    "applicableConfigs" : [
+    "applicableConfigs": [
       "main"
     ],
     "issueDetail" : {
@@ -6021,7 +6021,7 @@
       "offset" : 870
     },
     "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1337",
+    "modification" : "concurrent-1329",
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
   },
   {
@@ -6034,41 +6034,6 @@
     },
     "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
     "modification" : "concurrent-1328",
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
-  },
-  {
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 872
-    },
-    "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1330",
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
-  },
-  {
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueDetail" : {
-      "kind" : "cursorInfo",
-      "offset" : 872
-    },
-    "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1336",
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
-  },
-  {
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueDetail" : {
-      "kind" : "collectExpressionType"
-    },
-    "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1346",
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
   },
   {

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -6012,31 +6012,6 @@
     "path": "*\/ACHNBrowserUI\/ACHNBrowserUI\/views\/turnips\/charts\/TurnipsChartVerticalLegend.swift"
   },
   {
-    "applicableConfigs": [
-      "main"
-    ],
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 8,
-      "offset" : 870
-    },
-    "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1329",
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
-  },
-  {
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueDetail" : {
-      "kind" : "cursorInfo",
-      "offset" : 857
-    },
-    "issueUrl" : "https://github.com/swiftlang/swift/issues/57045",
-    "modification" : "concurrent-1328",
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift"
-  },
-  {
     "applicableConfigs" : [
       "main"
     ],

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -124,6 +124,17 @@
   },
   {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1699",
+    "issueDetail" : {
+      "kind" : "collectExpressionType"
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
     "modification" : "concurrent-352",
     "issueDetail" : {
       "kind" : "rangeInfo",
@@ -264,8 +275,34 @@
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
     "modification" : "concurrent-1301",
     "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 8,
+      "offset" : 828
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1301",
+    "issueDetail" : {
       "kind" : "cursorInfo",
       "offset" : 830
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1689",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 345,
+      "offset" : 879
     },
     "applicableConfigs" : [
       "main", "release/6.0", "release/5.10"
@@ -302,6 +339,42 @@
     "issueDetail" : {
       "kind" : "codeComplete",
       "offset" : 444
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1322",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 857
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1337",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 872
+    },
+    "applicableConfigs" : [
+      "main", "release/6.0", "release/5.10"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/57045"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/Backend\/Sources\/Backend\/models\/Villager.swift",
+    "modification" : "concurrent-1343",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 878
     },
     "applicableConfigs" : [
       "main", "release/6.0", "release/5.10"


### PR DESCRIPTION
Revert a couple of XFAIL changes for swiftlang/swift#57045 that were the result of timeouts changing the edits being applied.