### PR TITLE
XFAIL package-distributed-system on Linux in 6.1 configuration

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -5354,7 +5354,16 @@
         "action": "BuildSwiftPackage",
         "build_tests": "true",
         "configuration": "release",
-        "tags": "swiftpm"
+  			"tags": "swiftpm",
+        "xfail": [
+          {
+  					"issue": "https://github.com/swiftlang/swift/issues/78863",
+            "compatibility": ["5.10"],
+            "branch": ["release/6.1"],
+            "job": ["source-compat"],
+            "platform": "Linux"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
The fix has been merged but it's still not available in all nightly toolchains, so we should XFAIL until then.