### PR TITLE
fix: Use DEFAULT_EXECUTE_TIMEOUT for swift package actions

### DIFF
--- a/project.py
+++ b/project.py
@@ -352,7 +352,7 @@ def build_swift_package(path, swiftc, swift_version, configuration,
     if added_swift_flags is not None:
         for flag in added_swift_flags.split():
             command += ["-Xswiftc", flag]
-    return common.check_execute(command, timeout=3600,
+    return common.check_execute(command, timeout=common.DEFAULT_EXECUTE_TIMEOUT,
                                 sandbox_profile=sandbox_profile,
                                 stdout=stdout, stderr=stderr,
                                 env=env)
@@ -377,7 +377,7 @@ def test_swift_package(path, swiftc, sandbox_profile,
     if (swift_branch not in ['swift-3.0-branch',
                              'swift-3.1-branch']):
         command.insert(2, '--disable-sandbox')
-    return common.check_execute(command, timeout=3600,
+    return common.check_execute(command, timeout=common.DEFAULT_EXECUTE_TIMEOUT,
                                 sandbox_profile=sandbox_profile,
                                 stdout=stdout, stderr=stderr,
                                 env=env)

--- a/project_precommit_check
+++ b/project_precommit_check
@@ -237,7 +237,7 @@ def check(project, swift_branch, swiftc, compatibility_version):
     ]
     common.debug_print("--- Executing build actions ---")
     try:
-        common.check_execute(runner_command, timeout=3600)
+        common.check_execute(runner_command, timeout=common.DEFAULT_EXECUTE_TIMEOUT)
     except common.ExecuteCommandFailure:
         common.debug_print("--- Encountered failures. Check .log files in current directory for details ---")
         return 1

--- a/reproduce.py
+++ b/reproduce.py
@@ -112,7 +112,7 @@ def main():
             run_command += ['--skip-clone']
         if args.assertions:
             run_command += ['--assertions']
-        common.check_execute(run_command, timeout=3600)
+        common.check_execute(run_command, timeout=common.DEFAULT_EXECUTE_TIMEOUT)
 
     # Build specified indexed project. Otherwise, build all indexed projects
     runner_command = [


### PR DESCRIPTION
### Pull Request Description
Fixes a bug where adjusting timeouts using the `--default-timeout` argument doesn't work for swift package actions. These timeouts were hardcoded instead of using the argument value, which prevented the argument from having an effect.

I found a few other instances of hard-coded timeouts in `project_precommit_check` and `reproduce.py`, and wanted to make those consistent even though those scripts do not have a timeout argument.

### Acceptance Criteria
N/A. Bug fix, no new projects are introduced.