### PR TITLE
Revert "Merge pull request #1005 from xedin/rdar-152672172-xfails"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1351,30 +1351,14 @@
         "scheme": "ReactiveExtensions-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.2", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-TestHelpers-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.2", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       }
     ]
   },
@@ -1637,15 +1621,7 @@
         "action": "BuildSwiftPackage",
         "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2297,15 +2273,7 @@
         "scheme": "ReactiveCocoa-macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2319,12 +2287,6 @@
             "compatibility": ["4.0", "5.0"],
             "branch": ["release/5.4"],
             "configuration": "debug",
-            "job": ["source-compat"]
-          },
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
             "job": ["source-compat"]
           }
         ]
@@ -2342,12 +2304,6 @@
             "branch": ["release/5.4"],
             "configuration": "debug",
             "job": ["source-compat"]
-          },
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
           }
         ]
       },
@@ -2356,15 +2312,7 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       }
     ]
   },
@@ -2457,60 +2405,28 @@
         "scheme": "ReactiveSwift-macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "rdar://152672172",
-            "compatibility": ["4.0", "5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
This reverts commit 1690bc4e8e23fe17f4fe753a8354dde71e6e6ece, reversing changes made to 37d33ab2560f68ca78734638f77829a2d3cfee24.

The xfailed tests seem to have been fixed by
"Wrap SE-0481 into an upcoming feature until source incompatibilities are resolved"

https://github.com/swiftlang/swift/pull/82732.
