### PR TITLE
Un-XFAIL SwiftLint-Legacy for release/6.1 and release/6.2 branches

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3210,8 +3210,17 @@
             "issue": "https://github.com/apple/swift/issues/61616",
             "compatibility": ["4.0", "4.2"],
             "branch": ["main",  "release/6.0", "release/6.1", "release/6.2"],
-            "job": ["source-compat"]
+            "job": ["source-compat"],
+            "configuration": ["debug"]
+          },
+          {
+            "issue": "rdar://159565344",
+            "compatibility": ["4.0", "4.2"],
+            "branch": ["main"],
+            "job": ["source-compat"],
+            "configuration": ["release"]
           }
+             
         ]
       },
       {


### PR DESCRIPTION
SwiftLint-Legacy is UPASS-ing on release/6.1 and release/6.2 branches, so this patch is making sure those two are not XFAILed.

(This PR fixes the inadvertent XFAIL for release branches done in https://github.com/swiftlang/swift-source-compat-suite/pull/1020.)

rdar://161852011

