### PR TITLE
Update xfails.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1075,7 +1075,6 @@
             "platform": "Darwin",
             "compatibility": "5.0",
             "branch": [
-              "main",
               "release/6.0",
               "release/6.1",
               "release/6.2"
@@ -3461,7 +3460,6 @@
             "platform": "Darwin",
             "compatibility": "5.7",
             "branch": [
-              "main",
               "release/6.0",
               "release/6.1",
               "release/6.2"


### PR DESCRIPTION
`swift-distributed-actors` and `grpc-swift` are now UPASSing on main, so remove the xfail for main.

rdar://163508230
