### PR TITLE
Python 3.13 support - use explicit namespaces

### DIFF
--- a/project.py
+++ b/project.py
@@ -797,8 +797,8 @@ def evaluate_predicate(element, predicate):
     ns = {}
     for key in element:
         if isinstance(element[key], str):
-            exec(key + ' = """' + element[key] + '"""', locals=ns)
-    return eval(predicate, locals=ns)
+            exec(key + ' = """' + element[key] + '"""', ns)
+    return eval(predicate, ns)
 
 
 def included_element(include_predicates, exclude_predicates, element):


### PR DESCRIPTION
### Pull Request Description
* Add support for Python 3.13

With 3.13, you need to use explicit namespaces when declaring scoped variables via `exec` and `eval`

https://docs.python.org/3/whatsnew/3.13.html#defined-mutation-semantics-for-locals