### PR TITLE
Bump revision for swift-power-assert

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3018,8 +3018,8 @@
     "maintainer": "kishikawakatsumi@mac.com",
     "compatibility": [
       {
-        "version": "5.0",
-        "commit": "a60cb50b141d723ec51c1788fe454e93d468d5de"
+        "version": "5.9",
+        "commit": "e06a8c7588b01957228a59d5009fd24c31f6de38"
       }
     ],
     "platforms": [
@@ -3029,15 +3029,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke",
-        "xfail": [
-            {
-                "issue": "Only Supports 5.9+",
-                "compatibility": "5.0",
-                "branch": ["release/5.8"],
-                "job": ["source-compat"]
-            }
-        ]
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
The previous revision depended on a version of swift-syntax that had some code that should have never been accepted by the compiler (see https://github.com/swiftlang/swift/pull/85535 for more info). Bump the revision to a new enough version that has a new enough swift-syntax dependency. I have verified that the new revision builds with Xcode 15.2.