### PR TITLE
swift-distributed-actors avoid timeout

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3421,6 +3421,7 @@
     "path": "swift-distributed-actors",
     "branch": "main",
     "maintainer": "ktoso@apple.com",
+    "build_first": true,
     "compatibility": [
       {
         "version": "5.7",
@@ -3445,18 +3446,6 @@
             "branch": [
               "release/6.0",
               "release/6.1"
-            ],
-            "job": [
-              "source-compat"
-            ]
-          },
-          {
-            "issue": "https://github.com/swiftlang/swift/issues/85215",
-            "platform": "Darwin",
-            "compatibility": "5.7",
-            "configuration": "release",
-            "branch": [
-              "main"
             ],
             "job": [
               "source-compat"


### PR DESCRIPTION
Avoid timeouts caused my multiprocessing distributed-actors later in the build process