### PR TITLE
Update URL for Kronos project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1471,7 +1471,7 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/lyft/Kronos.git",
+    "url": "https://github.com/MobileNativeFoundation/Kronos.git",
     "path": "Kronos",
     "branch": "main",
     "maintainer": "Reflejo@gmail.com",


### PR DESCRIPTION
Looks like the project got moved and the current URL no longer works.

```
$ git clone https://github.com/lyft/Kronos.git /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/Kronos
Cloning into '/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/Kronos'...
fatal: unable to access 'https://github.com/lyft/Kronos.git/': CONNECT tunnel failed, response 503
```
