### PR TITLE
[common] account for processes which want to run without timeout

### DIFF
--- a/common.py
+++ b/common.py
@@ -145,6 +145,8 @@ def execute(command, timeout=None,
     """
     if timeout is None:
         timeout = DEFAULT_EXECUTE_TIMEOUT
+    elif timeout < 0:
+        timeout = None
     shell_debug_print(command, stderr=stderr)
     returncode = 124  # timeout return code
     try:


### PR DESCRIPTION
### Pull Request Description

* Account for users who want to run a process without a timeout by passing -1 to the timeout param. This is what we do when stress testing, and the value should be respected
```python
execute(
    command, 
    timeout=-1,
    stdout=stdout, 
    stderr=stderr,
    **kwargs
)
```
