### PR TITLE
Reenable package distributed system

### DIFF
--- a/projects/package-distributed-system.json
+++ b/projects/package-distributed-system.json
@@ -19,23 +19,7 @@
       "action": "BuildSwiftPackage",
       "build_tests": "true",
       "configuration": "release",
-      "tags": "swiftpm",
-      "xfail": [
-        {
-          "issue": "https://github.com/swiftlang/swift/issues/78863",
-          "compatibility": [
-            "5.10"
-          ],
-          "branch": [
-            "release/6.1"
-          ],
-          "job": [
-            "source-compat"
-          ],
-          "configuration": "release",
-          "platform": "Linux"
-        }
-      ]
+      "tags": "swiftpm"
     }
   ]
 }


### PR DESCRIPTION
Reproduce and/or attempt to adjust the ordoone/package-distributed-system  compat.

The failure was an exhaustive enum which isn't really a "swift bug" per se: https://github.com/swiftlang/swift/issues/78863