### PR TITLE
Unbreak swift-distributed-actors and its dependencies

### DIFF
--- a/projects/swift-cluster-membership.json
+++ b/projects/swift-cluster-membership.json
@@ -7,7 +7,7 @@
   "compatibility": [
     {
       "version": "6.1",
-      "commit": "b3db91894db64c01567983363d68f2350890c41e"
+      "commit": "0793910f7686d62627f57f3450592b770ddc4987"
     }
   ],
   "platforms": [

--- a/projects/swift-cluster-membership.json
+++ b/projects/swift-cluster-membership.json
@@ -18,11 +18,7 @@
     {
       "action": "BuildSwiftPackage",
       "configuration": "release",
-      "build_tests": "true",
       "tags": "sourcekit-disabled swiftpm"
-    },
-    {
-      "action": "TestSwiftPackage"
     }
   ]
 }

--- a/projects/swift-distributed-actors.json
+++ b/projects/swift-distributed-actors.json
@@ -7,7 +7,7 @@
   "build_first": true,
   "compatibility": [
     {
-      "version": "6.1",
+      "version": "5.10",
       "commit": "50e789fbb6db9a9869a60b1915e659bd752e1d42"
     }
   ],

--- a/projects/swift-distributed-actors.json
+++ b/projects/swift-distributed-actors.json
@@ -7,8 +7,8 @@
   "build_first": true,
   "compatibility": [
     {
-      "version": "5.7",
-      "commit": "e024c1fae5d2b17346c8a2c4482675a70f35fccc"
+      "version": "6.1",
+      "commit": "50e789fbb6db9a9869a60b1915e659bd752e1d42"
     }
   ],
   "platforms": [
@@ -20,33 +20,7 @@
       "action": "BuildSwiftPackage",
       "build_tests": "true",
       "build_tests_release": "true",
-      "configuration": "debug",
-      "xfail": [
-        {
-          "issue": "https://github.com/swiftlang/swift-package-manager/issues/7470",
-          "platform": "Darwin",
-          "compatibility": "5.7",
-          "branch": [
-            "release/6.0",
-            "release/6.1"
-          ],
-          "job": [
-            "source-compat"
-          ]
-        },
-        {
-          "issue": "https://github.com/swiftlang/swift/issues/90052",
-          "platform": "Darwin",
-          "compatibility": "5.7",
-          "branch": [
-            "main",
-            "release/6.4.x"
-          ],
-          "job": [
-            "source-compat"
-          ]
-        }
-      ]
+      "configuration": "debug"
     }
   ]
 }


### PR DESCRIPTION
The pinned 5.7 commit declares macOS(.v13) and depends on swift-cluster-membership without a version bound; SwiftPM resolves a recent cluster-membership release whose products require macOS(.v15), producing:

    error: The package product 'SWIM-product' requires minimum platform version 15.0 for the macOS platform, but this target supports 13.0

swift-distributed-actors itself has been on swift-tools-version 6.1 with macOS(.v15) for some time, so bump the source-compat baseline accordingly. The 5.7 SwiftPM xfail (#7470) becomes obsolete with this bump and is removed.
