### PR TITLE
watchOS platform: configure valid architectures, bump deployment target

### DIFF
--- a/project.py
+++ b/project.py
@@ -158,14 +158,17 @@ class XcodeTarget(ProjectTarget):
                       'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO',
                       "IPHONEOS_DEPLOYMENT_TARGET=16.0",
                       "MACOSX_DEPLOYMENT_TARGET=10.13",
-                      "WATCHOS_DEPLOYMENT_TARGET=4.0",
+                      "WATCHOS_DEPLOYMENT_TARGET=9.0",
                       "TVOS_DEPLOYMENT_TARGET=16.0",
                       "SDK_STAT_CACHE_ENABLE=NO",
                       ])
         command += self._added_xcodebuild_flags
 
         if self._destination == 'generic/platform=watchOS':
-            command += ['ARCHS=armv7k']
+            # This is akin to setting ARCHS properly
+            # in the project -- see for reference
+            # https://developer.apple.com/documentation/technotes/tn3117-resolving-build-errors-for-apple-silicon
+            command += ['VALID_ARCHS=$(ARCHS_STANDARD)']
         if self._destination == 'generic/platform=iOS':
             command += ['EXCLUDED_ARCHS=armv7 armv7s']
 
@@ -221,14 +224,17 @@ class XcodeTarget(ProjectTarget):
                       'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO',
                       "IPHONEOS_DEPLOYMENT_TARGET=16.0",
                       "MACOSX_DEPLOYMENT_TARGET=10.13",
-                      "WATCHOS_DEPLOYMENT_TARGET=4.0",
+                      "WATCHOS_DEPLOYMENT_TARGET=9.0",
                       "TVOS_DEPLOYMENT_TARGET=16.0",
                       "SDK_STAT_CACHE_ENABLE=NO",
                       ])
         command += self._added_xcodebuild_flags
 
         if self._destination == 'generic/platform=watchOS':
-            command += ['ARCHS=armv7k']
+            # This is akin to setting ARCHS properly
+            # in the project -- see for reference
+            # https://developer.apple.com/documentation/technotes/tn3117-resolving-build-errors-for-apple-silicon
+            command += ['VALID_ARCHS=$(ARCHS_STANDARD)']
 
         return command
 

--- a/projects/mapper.json
+++ b/projects/mapper.json
@@ -46,32 +46,11 @@
       "configuration": "Release"
     },
     {
-      "action": "BuildXcodeProjectTarget",
+      "action": "BuildXcodeProjectScheme",
       "project": "Mapper.xcodeproj",
-      "target": "Mapper",
+      "scheme": "Mapper",
       "destination": "generic/platform=watchOS",
-      "configuration": "Release",
-      "xfail": [
-        {
-          "issue": "https://github.com/apple/swift/issues/65197",
-          "compatibility": [
-            "4.0",
-            "4.2",
-            "5.0"
-          ],
-          "branch": [
-            "main",
-            "release/6.0",
-            "release/6.1",
-            "release/6.2",
-            "release/6.3",
-            "release/6.4.x"
-          ],
-          "job": [
-            "source-compat"
-          ]
-        }
-      ]
+      "configuration": "Release"
     },
     {
       "action": "BuildSwiftPackage",

--- a/projects/procedurekit.json
+++ b/projects/procedurekit.json
@@ -34,31 +34,11 @@
       "configuration": "Release"
     },
     {
-      "action": "BuildXcodeProjectTarget",
+      "action": "BuildXcodeProjectScheme",
       "project": "ProcedureKit.xcodeproj",
-      "target": "ProcedureKit",
+      "scheme": "ProcedureKit",
       "destination": "generic/platform=watchOS",
-      "configuration": "Release",
-      "xfail": [
-        {
-          "issue": "https://github.com/apple/swift/issues/65197",
-          "compatibility": [
-            "4.2",
-            "5.0"
-          ],
-          "branch": [
-            "main",
-            "release/6.0",
-            "release/6.1",
-            "release/6.2",
-            "release/6.3",
-            "release/6.4.x"
-          ],
-          "job": [
-            "source-compat"
-          ]
-        }
-      ]
+      "configuration": "Release"
     },
     {
       "action": "BuildXcodeProjectTarget",

--- a/projects/promisekit.json
+++ b/projects/promisekit.json
@@ -35,31 +35,11 @@
       "configuration": "Release"
     },
     {
-      "action": "BuildXcodeProjectTarget",
+      "action": "BuildXcodeProjectScheme",
       "project": "PromiseKit.xcodeproj",
-      "target": "PromiseKit",
+      "scheme": "PromiseKit",
       "destination": "generic/platform=watchOS",
-      "configuration": "Release",
-      "xfail": [
-        {
-          "issue": "https://github.com/apple/swift/issues/65197",
-          "compatibility": [
-            "4.0",
-            "5.0"
-          ],
-          "branch": [
-            "main",
-            "release/6.0",
-            "release/6.1",
-            "release/6.2",
-            "release/6.3",
-            "release/6.4.x"
-          ],
-          "job": [
-            "source-compat"
-          ]
-        }
-      ]
+      "configuration": "Release"
     },
     {
       "action": "BuildXcodeProjectTarget",

--- a/projects/rxswift.json
+++ b/projects/rxswift.json
@@ -79,28 +79,88 @@
       "scheme": "RxCocoa",
       "destination": "platform=macOS",
       "configuration": "Release",
-      "tags": "sourcekit-disabled"
+      "tags": "sourcekit-disabled",
+      "xfail": [
+        {
+          "issue": "https://github.com/swiftlang/swift/issues/90053",
+          "compatibility": [
+            "5.0"
+          ],
+          "branch": [
+            "main"
+          ],
+          "job": [
+            "source-compat"
+          ],
+          "platform": "Darwin"
+        }
+      ]
     },
     {
       "action": "BuildXcodeWorkspaceScheme",
       "workspace": "Rx.xcworkspace",
       "scheme": "RxCocoa",
       "destination": "generic/platform=iOS",
-      "configuration": "Release"
+      "configuration": "Release",
+      "xfail": [
+        {
+          "issue": "https://github.com/swiftlang/swift/issues/90053",
+          "compatibility": [
+            "5.0"
+          ],
+          "branch": [
+            "main"
+          ],
+          "job": [
+            "source-compat"
+          ],
+          "platform": "Darwin"
+        }
+      ]
     },
     {
       "action": "BuildXcodeWorkspaceScheme",
       "workspace": "Rx.xcworkspace",
       "scheme": "RxCocoa",
       "destination": "generic/platform=tvOS",
-      "configuration": "Release"
+      "configuration": "Release",
+      "xfail": [
+        {
+          "issue": "https://github.com/swiftlang/swift/issues/90053",
+          "compatibility": [
+            "5.0"
+          ],
+          "branch": [
+            "main"
+          ],
+          "job": [
+            "source-compat"
+          ],
+          "platform": "Darwin"
+        }
+      ]
     },
     {
       "action": "BuildXcodeWorkspaceScheme",
       "workspace": "Rx.xcworkspace",
       "scheme": "RxCocoa",
       "destination": "generic/platform=watchOS",
-      "configuration": "Release"
+      "configuration": "Release",
+      "xfail": [
+        {
+          "issue": "https://github.com/swiftlang/swift/issues/90053",
+          "compatibility": [
+            "5.0"
+          ],
+          "branch": [
+            "main"
+          ],
+          "job": [
+            "source-compat"
+          ],
+          "platform": "Darwin"
+        }
+      ]
     },
     {
       "action": "BuildXcodeWorkspaceScheme",

--- a/projects/swift-distributed-actors.json
+++ b/projects/swift-distributed-actors.json
@@ -33,6 +33,18 @@
           "job": [
             "source-compat"
           ]
+        },
+        {
+          "issue": "https://github.com/swiftlang/swift/issues/90052",
+          "platform": "Darwin",
+          "compatibility": "5.7",
+          "branch": [
+            "main",
+            "release/6.4.x"
+          ],
+          "job": [
+            "source-compat"
+          ]
         }
       ]
     }


### PR DESCRIPTION
This will prevent errors like
    
```
<unknown>:0: error: IR generation failure: Cannot read legacy layout
file at
 '/Users/ec2-user/jenkins/workspace-private/swift-PR-source-compat-suite-debug-macos/build/compat_macos/install/toolchain/usr/lib/swift/watchos/layouts-armv7k.yaml'
```
    
```
.../swift-source-compat-suite/project_cache/Alamofire/Alamofire.xcodeproj:
error: The watchOS deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set
to 4.0, but the range of supported deployment target versions is 9.0 to
27.0.x. (in target 'Alamofire watchOS' from project 'Alamofire')
```
    
which started happening after
https://github.com/swiftlang/swift/pull/89774

Also take the chances to update the watchOS configurations for Mapper, ProcedureKit and PromiseKit
    
Fixes swiftlang/swift#65197