### PR TITLE
XFAIL RxCocoa scheme for RxSwift only in release configurations

### DIFF
--- a/projects/rxswift.json
+++ b/projects/rxswift.json
@@ -92,7 +92,8 @@
           "job": [
             "source-compat"
           ],
-          "platform": "Darwin"
+          "platform": "Darwin",
+          "configuration": "release"
         }
       ]
     },
@@ -114,7 +115,8 @@
           "job": [
             "source-compat"
           ],
-          "platform": "Darwin"
+          "platform": "Darwin",
+          "configuration": "release"
         }
       ]
     },
@@ -136,7 +138,8 @@
           "job": [
             "source-compat"
           ],
-          "platform": "Darwin"
+          "platform": "Darwin",
+          "configuration": "release"
         }
       ]
     },
@@ -158,7 +161,8 @@
           "job": [
             "source-compat"
           ],
-          "platform": "Darwin"
+          "platform": "Darwin",
+          "configuration": "release"
         }
       ]
     },


### PR DESCRIPTION
In #1069 I missed this did not fail in debug configurations, and this is now causing an unwanted UPASS

Addresses rdar://180340169