### PR TITLE
XPASS Nimble on release/6.4.x and release/6.4.0

### DIFF
--- a/projects/nimble.json
+++ b/projects/nimble.json
@@ -29,9 +29,7 @@
             "release/6.0",
             "release/6.1",
             "release/6.2",
-            "release/6.3",
-            "release/6.4.x",
-            "release/6.4.0"
+            "release/6.3"
           ],
           "configuration": "debug",
           "job": [


### PR DESCRIPTION
Nimble UPASS on `release/6.4.x`: https://ci.swift.org/view/Swift%206.4.x/job/swift-6.4.x-source-compat-suite-debug-apple-silicon/27/.

`release/6.4.0` results are expected to match those on `release/6.4.x`.